### PR TITLE
Remove default window size config

### DIFF
--- a/ghostty/.config/ghostty/config
+++ b/ghostty/.config/ghostty/config
@@ -14,10 +14,6 @@ shell-integration = detect
 font-family = Hasklig
 font-size = 12
 
-# Due to a bug in gtk window decorations, these wont exactly match 92x24
-window-height = 27
-window-width = 92
-
 #####################
 # Colors
 #####################


### PR DESCRIPTION
I dont need this to affect all platforms only gtk.